### PR TITLE
 Support latest fbneo core and change ui_menu combo

### DIFF
--- a/pfba/CMakeLists.txt
+++ b/pfba/CMakeLists.txt
@@ -44,7 +44,10 @@ list(REMOVE_ITEM SRC_BURNER
         ${CMAKE_SOURCE_DIR}/cores/fba/src/burner/state.cpp
         ${CMAKE_SOURCE_DIR}/cores/fba/src/burner/unzip.c
         ${CMAKE_SOURCE_DIR}/cores/fba/src/burner/zipfn.cpp
+        ${CMAKE_SOURCE_DIR}/cores/fba/src/burner/luaengine.cpp
+        ${CMAKE_SOURCE_DIR}/cores/fba/src/burner/luasav.cpp
         )
+
 ##############
 # drivers
 ##############

--- a/ui/c2dui_ui_emu.cpp
+++ b/ui/c2dui_ui_emu.cpp
@@ -28,7 +28,7 @@ bool UIEmu::onInput(c2d::Input::Player *players) {
     }
 
     // look for player 1 menu combo
-    if (((players[0].keys & Input::Key::Fire5) && (players[0].keys & Input::Key::Fire6))) {
+    if (((players[0].keys & Input::Key::Start) && (players[0].keys & Input::Key::Fire6))) {
         pause();
         getUi()->getConfig()->load(getUi()->getUiRomList()->getSelection());
         getUi()->getUiMenu()->load(true);

--- a/ui/c2dui_ui_emu.cpp
+++ b/ui/c2dui_ui_emu.cpp
@@ -28,7 +28,7 @@ bool UIEmu::onInput(c2d::Input::Player *players) {
     }
 
     // look for player 1 menu combo
-    if (((players[0].keys & Input::Key::Start) && (players[0].keys & Input::Key::Select))) {
+    if (((players[0].keys & Input::Key::Fire5) && (players[0].keys & Input::Key::Fire6))) {
         pause();
         getUi()->getConfig()->load(getUi()->getUiRomList()->getSelection());
         getUi()->getUiMenu()->load(true);


### PR DESCRIPTION
Disable compilate lua things on latest fbneo core.
Change ui_menu combo in order to use Select+Start calling unibios menu on pFBA. (Now use L+R calling ui_menu)
Close #71 
Should fix #78 
And I think latest libcross2d should already fix #73 