### PR TITLE
Fix pfbneo target linking issue for MSYS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
+SET(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+SET(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
+
 # add libcross2d library. If you want to port pfba to another platform,
 # you should (may) only need to port libcross2d library.
 add_subdirectory(external/libcross2d)

--- a/src/cores/pgba/README.MD
+++ b/src/cores/pgba/README.MD
@@ -25,7 +25,7 @@ pGBA: Portable GameBoy Advance
 
 ### Installation (switch)
 
-- copy "pgba.nro" directory to "/pgba/pgen/" directory on sdcard
+- copy "pgba.nro" file to "/switch/pgba/" directory on sdcard
 - copy roms to "/switch/pgba/roms/" directory on sdcard
 
 ### Bios

--- a/src/cores/pgen/README.MD
+++ b/src/cores/pgen/README.MD
@@ -21,7 +21,7 @@ pGEN: Portable Genesis
 - Support hardware filtering (shaders)
 
 ### Installation (switch)
-- copy "pgen.nro" directory to "/switch/pgen/" directory on sdcard
+- copy "pgen.nro" file to "/switch/pgen/" directory on sdcard
 - copy gamegear roms to "/switch/pgen/gamegear/" directory on sdcard
 - copy megadrive roms to "/switch/pgen/megadrive/" directory on sdcard
 - copy master system roms to "/switch/pgen/mastersystem/" directory on sdcard


### PR DESCRIPTION
This PR will fix "Argument list too long" issue when linking pfbneo on MSYS toolchain. Now we will use "RESPONSE FILE" for cmake objects when building c++ source files.
I think this should be helpful for all building toolchain.
Also fix readme for pgba and pgen.