### PR TITLE
Fix PS4 startup black screen and pgen 4-player input routing

### DIFF
--- a/src/cores/main.cpp
+++ b/src/cores/main.cpp
@@ -17,7 +17,16 @@ int main(int argc, char **argv) {
     const auto io = new PEMUIo();
 
     // create main ui/renderer
-    pemu_ui = new PEMUUiMain(Vector2f{1280, 720});
+    // NOTE: size must stay {0, 0} on non-switch platforms (PS4, PS5, Vita, Linux, Windows...).
+    // libcross2d's SDL2Renderer only sets SDL_WINDOW_FULLSCREEN_DESKTOP when the requested
+    // size is <= 0 (see SDL2Renderer::SDL2Renderer in libcross2d/source/platforms/sdl2/sdl2_renderer.cpp).
+    // Passing a fixed size like {1280, 720} here creates a small, non-fullscreen SDL window,
+    // which on PS4 (no windowing system / no desktop compositor) never actually gets
+    // presented to the TV output -> black screen, even though audio keeps working fine
+    // since it's an independent subsystem. Switch ignores this parameter entirely and
+    // forces its own {1280, 720} internally (see UiMain's __SWITCH__ constructor), so it's
+    // safe to leave this at {0, 0} for every platform.
+    pemu_ui = new PEMUUiMain(Vector2f{0, 0});
     pemu_ui->setIo(io);
 
     // load configuration

--- a/src/cores/pgen/sources/pgen_ui_emu.cpp
+++ b/src/cores/pgen/sources/pgen_ui_emu.cpp
@@ -109,25 +109,45 @@ void PGENUiEmu::stop() {
 void PGENUiEmu::onUpdate() {
     if (!isPaused()) {
         // inputs
-        for (int i = 0; i < PLAYER_MAX; i++) {
-            unsigned int buttons = getUi()->getInput()->getButtons(i);
-            input.pad[i] = 0;
-            switch (input.dev[i]) {
+        //
+        // NOTE: Genesis-Plus-GX's input.dev[]/input.pad[] arrays are NOT indexed by
+        // simple player number (0-3). They're indexed by physical device "slot", per
+        // core/input_hw/input.c (input_init()):
+        //   slot 0     = port A, controller 1  (player 1)
+        //   slot 1-3   = port A extra devices  (4-Way Play / Team Player on port A only)
+        //   slot 4     = port B, controller 1  (player 2)
+        //   slot 5-6   = the two extra J-CART gamepads (player 3 & player 4), which the
+        //                core auto-enables when it detects a J-CART game at ROM load
+        //                (cart.special & HW_J_CART) - no extra setup needed here beyond
+        //                routing input to the right slot
+        //   slot 7     = port B extra device (Justifier 2P)
+        //
+        // The old code fed physical controller index i (0..PLAYER_MAX-1) straight into
+        // input.dev[i]/input.pad[i], which only lined up for player 1 (slot 0). Slots
+        // 1-3 are never populated for a plain 2-controller/J-CART setup, so every other
+        // physical controller was silently ignored - hence only 1 player worked, even
+        // in native 2-player Mega Drive games, let alone 4-player J-CART ones.
+        static const int genesisDeviceSlot[4] = {0, 4, 5, 6};
+        for (int p = 0; p < 4; p++) {
+            int dev = genesisDeviceSlot[p];
+            unsigned int buttons = getUi()->getInput()->getButtons(p);
+            input.pad[dev] = 0;
+            switch (input.dev[dev]) {
                 case DEVICE_PAD6B:
                 case DEVICE_PAD3B:
                 case DEVICE_PAD2B:
-                    if (buttons & Input::Button::Up) input.pad[i] |= INPUT_UP;
-                    if (buttons & Input::Button::Down) input.pad[i] |= INPUT_DOWN;
-                    if (buttons & Input::Button::Left) input.pad[i] |= INPUT_LEFT;
-                    if (buttons & Input::Button::Right) input.pad[i] |= INPUT_RIGHT;
-                    if (buttons & Input::Button::A) input.pad[i] |= INPUT_A;
-                    if (buttons & Input::Button::B) input.pad[i] |= INPUT_B;
-                    if (buttons & Input::Button::X) input.pad[i] |= INPUT_C;
-                    if (buttons & Input::Button::Y) input.pad[i] |= INPUT_X;
-                    if (buttons & Input::Button::LT) input.pad[i] |= INPUT_Y;
-                    if (buttons & Input::Button::RT) input.pad[i] |= INPUT_Z;
-                    if (buttons & Input::Button::Select) input.pad[i] |= INPUT_MODE;
-                    if (buttons & Input::Button::Start) input.pad[i] |= INPUT_START;
+                    if (buttons & Input::Button::Up) input.pad[dev] |= INPUT_UP;
+                    if (buttons & Input::Button::Down) input.pad[dev] |= INPUT_DOWN;
+                    if (buttons & Input::Button::Left) input.pad[dev] |= INPUT_LEFT;
+                    if (buttons & Input::Button::Right) input.pad[dev] |= INPUT_RIGHT;
+                    if (buttons & Input::Button::A) input.pad[dev] |= INPUT_A;
+                    if (buttons & Input::Button::B) input.pad[dev] |= INPUT_B;
+                    if (buttons & Input::Button::X) input.pad[dev] |= INPUT_C;
+                    if (buttons & Input::Button::Y) input.pad[dev] |= INPUT_X;
+                    if (buttons & Input::Button::LT) input.pad[dev] |= INPUT_Y;
+                    if (buttons & Input::Button::RT) input.pad[dev] |= INPUT_Z;
+                    if (buttons & Input::Button::Select) input.pad[dev] |= INPUT_MODE;
+                    if (buttons & Input::Button::Start) input.pad[dev] |= INPUT_START;
                     break;
                 default:
                     break;


### PR DESCRIPTION
Two related PS4 fixes, bundled together since they were found/fixed in the same session:

1. Startup/menu black screen: PEMUUiMain was constructed with a fixed windowed
   size (Vector2f{1280, 720}), which makes SDL create a windowed surface - the
   PS4 can't display that outside its expected fullscreen swapchain, so the app
   showed a permanent black screen from launch. Passing Vector2f{0, 0} instead
   triggers true SDL fullscreen and fixes it. Affects v7.0 and v7.1 on PS4.

2. pgen only responding to player 1 (and 4-player J-Cart games showing no
   input on players 3/4): Genesis-Plus-GX indexes its input.dev[]/input.pad[]
   arrays by a fixed hardware slot (0 = Port A/P1, 4 = Port B/P2, 5-6 = the two
   J-Cart gamepads for P3/P4), not by physical controller index. The onUpdate()
   loop in pgen_ui_emu.cpp was feeding the physical controller index straight
   into that array, so only controller 0 -> slot 0 ever lined up - controller 1
   landed on a dead slot and produced no input, even in a plain 2-player
   Mega Drive game (not just J-Cart titles). Fixed by mapping physical
   controller index -> correct device slot: {0, 4, 5, 6} for P1-P4.

Both confirmed fixed and tested working on PS4 hardware (GoldHEN-jailbroken,
4x controllers via 2 Hori fight sticks + DualShock 4s).